### PR TITLE
236 v2 cms pages

### DIFF
--- a/app/.eslintrc.js
+++ b/app/.eslintrc.js
@@ -21,5 +21,14 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    "@typescript-eslint/ban-ts-ignore": [
+        'off',
+      {
+        'ts-expect-error': 'allow-with-description',
+        'ts-ignore': 'allow-with-description',
+        'ts-nocheck': 'allow-with-description',
+        'ts-check': 'allow-with-description',
+      }
+    ]
   },
 };

--- a/app/.prettierignore
+++ b/app/.prettierignore
@@ -1,0 +1,1 @@
+Route.tsx

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -11074,6 +11074,13 @@
         "url": "https://opencollective.com/immer"
       }
     },
+    "node_modules/immutable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
+      "integrity": "sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw==",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/import-cwd": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
@@ -18819,6 +18826,24 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/sanitize.css/-/sanitize.css-10.0.0.tgz",
       "integrity": "sha512-vTxrZz4dX5W86M6oVWVdOVe72ZiPs41Oi7Z6Km4W5Turyz28mrXSJhhEBZoRtzJWIv3833WKVwLSDWWkEfupMg=="
+    },
+    "node_modules/sass": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.45.1.tgz",
+      "integrity": "sha512-pwPRiq29UR0o4X3fiQyCtrESldXvUQAAE0QmcJTpsI4kuHHcLzZ54M1oNBVIXybQv8QF2zfkpFcTxp8ta97dUA==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
     },
     "node_modules/sass-loader": {
       "version": "10.2.0",
@@ -31835,6 +31860,13 @@
       "resolved": "https://registry.npmjs.org/immer/-/immer-8.0.1.tgz",
       "integrity": "sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA=="
     },
+    "immutable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
+      "integrity": "sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw==",
+      "optional": true,
+      "peer": true
+    },
     "import-cwd": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
@@ -37949,6 +37981,18 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/sanitize.css/-/sanitize.css-10.0.0.tgz",
       "integrity": "sha512-vTxrZz4dX5W86M6oVWVdOVe72ZiPs41Oi7Z6Km4W5Turyz28mrXSJhhEBZoRtzJWIv3833WKVwLSDWWkEfupMg=="
+    },
+    "sass": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.45.1.tgz",
+      "integrity": "sha512-pwPRiq29UR0o4X3fiQyCtrESldXvUQAAE0QmcJTpsI4kuHHcLzZ54M1oNBVIXybQv8QF2zfkpFcTxp8ta97dUA==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      }
     },
     "sass-loader": {
       "version": "10.2.0",

--- a/app/src/components/NavList.tsx
+++ b/app/src/components/NavList.tsx
@@ -95,7 +95,7 @@ const NavList: React.FC<NavListType> = ({
 
             {/*Add the arrow at the right, if there is a link*/}
             <IonNote slot={"end"}>
-              {item.link && <FontAwesomeIcon icon={"arrow-right"} />}
+              {item.link && <FontAwesomeIcon icon={"chevron-right"} />}
             </IonNote>
           </IonItem>
 

--- a/app/src/components/NavList.tsx
+++ b/app/src/components/NavList.tsx
@@ -1,0 +1,127 @@
+import { IonItem, IonLabel, IonList, IonNote } from "@ionic/react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { IconProp } from "@fortawesome/fontawesome-svg-core";
+import StyledIonSkeletonText from "./StyledIonSkeletonText";
+import { Fragment as ReactFragment } from "react";
+
+export type NavListItemType = {
+  icon?: IconProp;
+  content: any;
+  link?: string;
+  subItems?: NavListItemType[];
+};
+
+type NavListType = {
+  items?: NavListItemType[];
+  isLoading?: boolean;
+  loadingCount?: number;
+};
+
+/**
+ * Creates a navigation list much like the example found at
+ * https://ionicframework.com/docs/api/nav (although this page
+ * talks about nav events, the example is what has been created here).
+ *
+ * Pass a list of items in the following format and it builds the rest
+ * [
+ *    {
+ *      icon:
+ *      content:
+ *      link:
+ *      subItems: []
+ *    }
+ * ]
+ *
+ * The only item that is required is content. The rest just add features
+ * to the list item
+ *
+ * @param items The list as defined above or in NavListItemType[]
+ * @param isLoading This is boolean and if set to true, it will provide
+ *                  a number (based off loadingCount) of skeletons for loading
+ * @param loadingCount defaults to 7. The number of skeleton items to display
+ *                     when isLoading is set to true
+ */
+const NavList: React.FC<NavListType> = ({
+  items = [],
+  isLoading = false,
+  loadingCount = 7,
+}) => {
+  /**
+   * Use recursion to take a list of nav items and generate the content.
+   * Because recursion of used the depth of sub items can be infinite.
+   *
+   * @param list The list of nav items
+   * @param depth the depth that this list is
+   */
+  function generateItemsList(list: NavListItemType[], depth = 0): any {
+    // Map the list if items
+    return list.map((item: NavListItemType, index: number) => {
+      return (
+        <ReactFragment key={`${depth}-${index}`}>
+          <IonItem routerLink={item.link}>
+            {/*Generate the spacers or arrows if the depth is not 0*/}
+            {[...Array(depth)].map((e, spacer_index) => {
+              return (
+                <IonNote
+                  slot={"start"}
+                  key={`${depth}-${index}-${spacer_index}`}
+                >
+                  {spacer_index == depth - 1 ? (
+                    "↳"
+                  ) : (
+                    <FontAwesomeIcon
+                      icon={
+                        spacer_index == depth - 1
+                          ? "arrow-alt-circle-down"
+                          : "square"
+                      }
+                      color={"transparent"}
+                    />
+                  )}
+                </IonNote>
+              );
+            })}
+
+            {/*Generate the Icon, otherwise put a transparent placeholder in for width purposes*/}
+            <IonNote slot={"start"}>
+              <FontAwesomeIcon
+                icon={item.icon ? item.icon : "square"}
+                color={item.icon ? undefined : "transparent"}
+              />
+            </IonNote>
+
+            {/*Add the content*/}
+            <IonLabel>{item.content}</IonLabel>
+
+            {/*Add the arrow at the right, if there is a link*/}
+            <IonNote slot={"end"}>
+              {item.link && <FontAwesomeIcon icon={"arrow-right"} />}
+            </IonNote>
+          </IonItem>
+
+          {/*Generate all the sub items using recursion*/}
+          {item.subItems && generateItemsList(item.subItems, depth + 1)}
+        </ReactFragment>
+      );
+    });
+  }
+
+  // Return a Ionic list with the content
+  return (
+    <IonList>
+      {/*If is loading is set we want to generate a number of SkeletonTexts based off loadingCount */}
+      {/*and display them. Otherwise we will generate the list items*/}
+      {isLoading
+        ? generateItemsList(
+            [...Array(loadingCount)].map((e, index) => {
+              return {
+                content: <StyledIonSkeletonText animated key={index} />,
+              };
+            }),
+          )
+        : generateItemsList(items)}
+    </IonList>
+  );
+};
+
+export default NavList;

--- a/app/src/components/Page.tsx
+++ b/app/src/components/Page.tsx
@@ -11,7 +11,7 @@ import {
 import PageTitle from "./PageTitle";
 
 type Props = {
-  title?: string;
+  title?: any;
   children?: any;
 };
 

--- a/app/src/components/Refresher.tsx
+++ b/app/src/components/Refresher.tsx
@@ -1,0 +1,31 @@
+import {
+  IonRefresher,
+  IonRefresherContent,
+  RefresherEventDetail,
+} from "@ionic/react";
+
+interface RefresherProps {
+  onRefresh: ((event: CustomEvent<RefresherEventDetail>) => void) | undefined;
+}
+
+/**
+ * Creates a standard Ionic Refresher for use in all parts of the project
+ * @param onRefresh the function to call on refresh
+ * @constructor
+ */
+const Refresher = ({ onRefresh }: RefresherProps) => {
+  return (
+    <IonRefresher
+      slot="fixed"
+      onIonRefresh={onRefresh}
+      closeDuration={"280ms"}
+      pullFactor={1}
+      pullMin={60}
+      snapbackDuration={"280ms"}
+    >
+      <IonRefresherContent />
+    </IonRefresher>
+  );
+};
+
+export default Refresher;

--- a/app/src/components/SkeletonCard.tsx
+++ b/app/src/components/SkeletonCard.tsx
@@ -1,0 +1,33 @@
+import {
+  IonCard,
+  IonCardContent,
+  IonCardHeader,
+  IonCardTitle,
+} from "@ionic/react";
+import StyledIonSkeletonText from "./StyledIonSkeletonText";
+
+/**
+ * Creates an Ionic card with a skeleton text title and
+ * 6 skeleton text items to form a "paragraph"
+ */
+const SkeletonCard: React.FC = () => {
+  return (
+    <IonCard>
+      <IonCardHeader>
+        <IonCardTitle>
+          <StyledIonSkeletonText animated />
+        </IonCardTitle>
+      </IonCardHeader>
+      <IonCardContent>
+        <StyledIonSkeletonText animated />
+        <StyledIonSkeletonText animated />
+        <StyledIonSkeletonText animated />
+        <StyledIonSkeletonText animated />
+        <StyledIonSkeletonText animated />
+        <StyledIonSkeletonText animated style={{ width: "40%" }} />
+      </IonCardContent>
+    </IonCard>
+  );
+};
+
+export default SkeletonCard;

--- a/app/src/components/StyledIonSkeletonText.ts
+++ b/app/src/components/StyledIonSkeletonText.ts
@@ -1,0 +1,8 @@
+import styled from "styled-components";
+import { IonSkeletonText } from "@ionic/react";
+
+const StyledIonSkeletonText = styled(IonSkeletonText)`
+  line-height: 13px;
+`;
+
+export default StyledIonSkeletonText;

--- a/app/src/components/SummernoteContent.ts
+++ b/app/src/components/SummernoteContent.ts
@@ -1,0 +1,51 @@
+import styled from "styled-components";
+
+/**
+ * Style content from a Summernote input on the dash. Ionic provides style for
+ * most things however this adapts the bootstrap styles to add responsive
+ * styling for tables, as well as correcting persistent link colour issues.
+ */
+const SummernoteContent = styled.div`
+  /**
+		Responsive Table Styles
+	 */
+  table {
+    width: 100%;
+    margin-bottom: 1rem;
+    overflow-x: auto;
+    display: block;
+    -webkit-overflow-scrolling: touch;
+
+    tbody,
+    thead {
+      display: table;
+      width: 100%;
+    }
+
+    th,
+    td {
+      padding: 0.75rem;
+      vertical-align: top;
+      border-top: 1px solid currentColor;
+    }
+
+    thead th {
+      vertical-align: bottom;
+      border-bottom: 2px solid currentColor;
+      filter: brightness(10%);
+    }
+
+    tbody + tbody {
+      border-top: 2px solid currentColor;
+    }
+  }
+
+  /**
+		Link Styles
+	 */
+  a {
+    color: currentColor;
+  }
+`;
+
+export default SummernoteContent;

--- a/app/src/components/menu/Menu.tsx
+++ b/app/src/components/menu/Menu.tsx
@@ -1,6 +1,5 @@
 import { IonMenu, IonMenuToggle } from "@ionic/react";
 import { useLocation } from "react-router-dom";
-import { faCube, faList } from "@fortawesome/free-solid-svg-icons";
 import { IconProp, SizeProp } from "@fortawesome/fontawesome-svg-core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import StyledIonContent from "./components/StyledIonContent";
@@ -31,7 +30,7 @@ const Menu: React.FC = () => {
     {
       title: "Assets",
       url: "/assets/",
-      icon: faCube,
+      icon: "cube",
     },
     {
       title: "CMS Pages",
@@ -42,7 +41,7 @@ const Menu: React.FC = () => {
     {
       title: "Projects",
       url: "/projects/",
-      icon: faList,
+      icon: "list",
     },
   ];
 

--- a/app/src/components/menu/Menu.tsx
+++ b/app/src/components/menu/Menu.tsx
@@ -1,10 +1,7 @@
 import { IonMenu, IonMenuToggle } from "@ionic/react";
 import { useLocation } from "react-router-dom";
-import {
-  faCube,
-  faList,
-  IconDefinition,
-} from "@fortawesome/free-solid-svg-icons";
+import { faCube, faList } from "@fortawesome/free-solid-svg-icons";
+import { IconProp, SizeProp } from "@fortawesome/fontawesome-svg-core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import StyledIonContent from "./components/StyledIonContent";
 import StyledIonList from "./components/StyledIonList";
@@ -13,29 +10,41 @@ import StyledIonLabel from "./components/StyledIonLabel";
 import BrandImage from "./components/BrandImage";
 import BrandContainer from "./components/BrandContainer";
 import BrandText from "./components/BrandText";
+import CmsPages from "./components/CmsPages";
+import SkeletonLink from "./components/SkeletonLink";
 
-interface AppPage {
-  url: string;
-  icon: IconDefinition;
-  title: string;
+export interface AppPage {
+  url: string | undefined;
+  icon?: IconProp | null;
+  title?: string;
+  subpage?: Array<AppPage>;
+  isLoading?: boolean;
 }
 
-//Add new pages to this array
-const appPages: AppPage[] = [
-  {
-    title: "Assets",
-    url: "/assets/",
-    icon: faCube,
-  },
-  {
-    title: "Projects",
-    url: "/projects/",
-    icon: faList,
-  },
-];
+const FONT_AWESOME_MULTIPLIER: SizeProp | undefined = "1x";
 
 const Menu: React.FC = () => {
   const location = useLocation();
+
+  //Add new pages to this array
+  const appPages: AppPage[] = [
+    {
+      title: "Assets",
+      url: "/assets/",
+      icon: faCube,
+    },
+    {
+      title: "CMS Pages",
+      url: "/cms/",
+      icon: ["far", "newspaper"],
+    },
+    ...CmsPages(),
+    {
+      title: "Projects",
+      url: "/projects/",
+      icon: faList,
+    },
+  ];
 
   return (
     <IonMenu contentId="main" type="overlay">
@@ -46,11 +55,20 @@ const Menu: React.FC = () => {
         </BrandContainer>
         <StyledIonList id="adamRMS-menu-list">
           {appPages.map((appPage, index) => {
+            if (appPage.isLoading) {
+              return (
+                <SkeletonLink
+                  fontAwesomeMultiplier={FONT_AWESOME_MULTIPLIER}
+                  key={index}
+                />
+              );
+            }
+
             return (
               <IonMenuToggle key={index} autoHide={false}>
                 <StyledIonItem
-                  className={
-                    location.pathname === appPage.url ? "selected" : ""
+                  color={
+                    location.pathname === appPage.url ? "medium" : undefined
                   }
                   routerLink={appPage.url}
                   routerDirection="none"
@@ -58,7 +76,12 @@ const Menu: React.FC = () => {
                   detail={false}
                 >
                   <StyledIonLabel slot="start">
-                    <FontAwesomeIcon icon={appPage.icon} size="2x" />
+                    {appPage.icon && (
+                      <FontAwesomeIcon
+                        icon={appPage.icon}
+                        size={FONT_AWESOME_MULTIPLIER}
+                      />
+                    )}
                   </StyledIonLabel>
                   <StyledIonLabel>{appPage.title}</StyledIonLabel>
                 </StyledIonItem>

--- a/app/src/components/menu/Menu.tsx
+++ b/app/src/components/menu/Menu.tsx
@@ -1,6 +1,6 @@
-import { IonMenu, IonMenuToggle } from "@ionic/react";
+import { IonItemDivider, IonLabel, IonMenu, IonMenuToggle } from "@ionic/react";
 import { useLocation } from "react-router-dom";
-import { IconProp, SizeProp } from "@fortawesome/fontawesome-svg-core";
+import { SizeProp } from "@fortawesome/fontawesome-svg-core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import StyledIonContent from "./components/StyledIonContent";
 import StyledIonList from "./components/StyledIonList";
@@ -11,37 +11,46 @@ import BrandContainer from "./components/BrandContainer";
 import BrandText from "./components/BrandText";
 import CmsPages from "./components/CmsPages";
 import SkeletonLink from "./components/SkeletonLink";
-
-export interface AppPage {
-  url: string | undefined;
-  icon?: IconProp | null;
-  title?: string;
-  subpage?: Array<AppPage>;
-  isLoading?: boolean;
-}
+import { MenuItem } from "./components/MenuItem";
 
 const FONT_AWESOME_MULTIPLIER: SizeProp | undefined = "1x";
 
+/**
+ * The Menu!
+ */
 const Menu: React.FC = () => {
   const location = useLocation();
 
-  //Add new pages to this array
-  const appPages: AppPage[] = [
+  // Add new pages to this array.
+  // The type must be set as defined in MenuItem.d.ts. This is
+  // normally either "item", "route", "separator" or "section but
+  // this may change so please check the file as you update this array.
+  const menuItems: MenuItem[] = [
     {
+      type: "route",
       title: "Assets",
       url: "/assets/",
       icon: "cube",
     },
     {
+      type: "route",
+      title: "Projects",
+      url: "/projects/",
+      icon: "list",
+    },
+    {
+      type: "route",
       title: "CMS Pages",
       url: "/cms/",
       icon: ["far", "newspaper"],
     },
+    {
+      type: "section",
+      title: "Pages",
+    },
     ...CmsPages(),
     {
-      title: "Projects",
-      url: "/projects/",
-      icon: "list",
+      type: "separator",
     },
   ];
 
@@ -53,8 +62,23 @@ const Menu: React.FC = () => {
           <BrandText>AdamRMS</BrandText>
         </BrandContainer>
         <StyledIonList id="adamRMS-menu-list">
-          {appPages.map((appPage, index) => {
-            if (appPage.isLoading) {
+          {menuItems.map((item, index) => {
+            // Render a seperator
+            if (item.type == "separator") {
+              return <IonItemDivider />;
+            }
+
+            // Render a section
+            if (item.type == "section") {
+              return (
+                <IonItemDivider>
+                  <IonLabel>{item.title}</IonLabel>
+                </IonItemDivider>
+              );
+            }
+            // If the code is at this point it must be either an item or a route
+            // We can therefore check if its loading
+            if (item.isLoading) {
               return (
                 <SkeletonLink
                   fontAwesomeMultiplier={FONT_AWESOME_MULTIPLIER}
@@ -63,29 +87,41 @@ const Menu: React.FC = () => {
               );
             }
 
-            return (
-              <IonMenuToggle key={index} autoHide={false}>
-                <StyledIonItem
-                  color={
-                    location.pathname === appPage.url ? "medium" : undefined
-                  }
-                  routerLink={appPage.url}
-                  routerDirection="none"
-                  lines="none"
-                  detail={false}
-                >
-                  <StyledIonLabel slot="start">
-                    {appPage.icon && (
-                      <FontAwesomeIcon
-                        icon={appPage.icon}
-                        size={FONT_AWESOME_MULTIPLIER}
-                      />
-                    )}
-                  </StyledIonLabel>
-                  <StyledIonLabel>{appPage.title}</StyledIonLabel>
-                </StyledIonItem>
-              </IonMenuToggle>
+            // Create the component for both a item or a route
+            const renderMenuItem = (
+              <StyledIonItem
+                color={
+                  item.type == "route" && location.pathname === item.url
+                    ? "medium"
+                    : undefined
+                }
+                routerLink={item.type == "route" ? item.url : undefined}
+                routerDirection="none"
+                lines="none"
+                detail={false}
+              >
+                <StyledIonLabel slot="start">
+                  {item.icon && (
+                    <FontAwesomeIcon
+                      icon={item.icon}
+                      size={FONT_AWESOME_MULTIPLIER}
+                    />
+                  )}
+                </StyledIonLabel>
+                <StyledIonLabel>{item.title}</StyledIonLabel>
+              </StyledIonItem>
             );
+
+            // If it is a route we want the menu to auto dismiss when it item is clicked
+            if (item.type == "route") {
+              return (
+                <IonMenuToggle key={index} autoHide={false}>
+                  {renderMenuItem}
+                </IonMenuToggle>
+              );
+            } else {
+              return renderMenuItem;
+            }
           })}
         </StyledIonList>
       </StyledIonContent>

--- a/app/src/components/menu/components/CmsPages.ts
+++ b/app/src/components/menu/components/CmsPages.ts
@@ -1,12 +1,12 @@
 import { useContext, useEffect, useState } from "react";
 import { CmsPageContext } from "../../../contexts/cms/CmsPageContext";
-import { AppPage } from "../Menu";
 import GenerateIconFromString from "../../../utilities/GenerateIconFromString";
+import { MenuItem } from "./MenuItem";
 
 /**
  * Gets the CMS page data from the api and converts it to a format for the menu
  */
-const CmsPages = () => {
+const CmsPages = (): MenuItem[] => {
   const { CmsPages, refreshPages } = useContext(CmsPageContext);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -22,19 +22,20 @@ const CmsPages = () => {
   if (isLoading) {
     return [
       {
-        url: undefined,
+        type: "item",
         isLoading: true,
       },
       {
-        url: undefined,
+        type: "item",
         isLoading: true,
       },
     ];
   }
 
   //Map the pages to the url, icon and title for use in the menu
-  return CmsPages.map(function (page: CmsPageList): AppPage {
+  return CmsPages.map(function (page: CmsPageList): MenuItem {
     return {
+      type: "route",
       url: `/cms/${page.cmsPages_id}/`,
       title: page.cmsPages_name,
       ...(page.cmsPages_fontAwesome && {

--- a/app/src/components/menu/components/CmsPages.ts
+++ b/app/src/components/menu/components/CmsPages.ts
@@ -1,0 +1,47 @@
+import { useContext, useEffect, useState } from "react";
+import { CmsPageContext } from "../../../contexts/cms/CmsPageContext";
+import { AppPage } from "../Menu";
+import GenerateIconFromString from "../../../utilities/GenerateIconFromString";
+
+/**
+ * Gets the CMS page data from the api and converts it to a format for the menu
+ */
+const CmsPages = () => {
+  const { CmsPages, refreshPages } = useContext(CmsPageContext);
+  const [isLoading, setIsLoading] = useState(false);
+
+  //Get data from API
+  useEffect(() => {
+    setIsLoading(true);
+    refreshPages().then(() => {
+      setIsLoading(false);
+    });
+  }, []);
+
+  // If loading then return some skeletons
+  if (isLoading) {
+    return [
+      {
+        url: undefined,
+        isLoading: true,
+      },
+      {
+        url: undefined,
+        isLoading: true,
+      },
+    ];
+  }
+
+  //Map the pages to the url, icon and title for use in the menu
+  return CmsPages.map(function (page: CmsPageList): AppPage {
+    return {
+      url: `/cms/${page.cmsPages_id}/`,
+      title: page.cmsPages_name,
+      ...(page.cmsPages_fontAwesome && {
+        icon: GenerateIconFromString(page.cmsPages_fontAwesome),
+      }),
+    };
+  });
+};
+
+export default CmsPages;

--- a/app/src/components/menu/components/MenuItem.d.ts
+++ b/app/src/components/menu/components/MenuItem.d.ts
@@ -1,0 +1,46 @@
+/*
+ The interface for a menu Item
+ */
+import { IconProp } from "@fortawesome/fontawesome-svg-core";
+
+interface MenuListItem {
+  icon?: IconProp | null;
+  title?: string;
+  isLoading?: boolean;
+}
+
+/*
+ The interface with just the props in MenuListItem (no link)
+ */
+interface BlankMenuItem extends MenuListItem {
+  type: "item";
+}
+
+/*
+A Menu Item that takes you somewhere (hopefully Central Hall)
+ */
+interface MenuItemRoute extends MenuListItem {
+  type: "route";
+  url: string;
+}
+
+/*
+A separator Menu Item
+ */
+interface MenuItemSeparator {
+  type: "separator";
+}
+
+/**
+ * A menu item that creates a heading for a section
+ */
+interface MenuItemSection {
+  type: "section";
+  title: string;
+}
+
+export type MenuItem =
+  | BlankMenuItem
+  | MenuItemRoute
+  | MenuItemSeparator
+  | MenuItemSection;

--- a/app/src/components/menu/components/SkeletonLink.tsx
+++ b/app/src/components/menu/components/SkeletonLink.tsx
@@ -1,0 +1,54 @@
+import StyledIonItem from "./StyledIonItem";
+import { IonSkeletonText } from "@ionic/react";
+import StyledIonLabel from "./StyledIonLabel";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { SizeProp } from "@fortawesome/fontawesome-svg-core";
+import styled from "styled-components";
+
+type SkeletonLinkType = {
+  fontAwesomeMultiplier?: SizeProp | undefined;
+};
+
+/**
+ * Create a skeleton link for the menu
+ *
+ * @param fontAwesomeMultiplier the size of font awesome icons being used in the menu
+ * @constructor
+ */
+const SkeletonLink: React.FC<SkeletonLinkType> = ({
+  fontAwesomeMultiplier = "1x",
+}) => {
+  return (
+    <StyledIonItem lines="none" detail={false}>
+      <StyledIonLabel slot="start">
+        <IconContainer>
+          <FontAwesomeIcon
+            icon={"square"}
+            size={fontAwesomeMultiplier}
+            color={"transparent"}
+          />
+          <StyledIonSkeletonText animated />
+        </IconContainer>
+      </StyledIonLabel>
+      <StyledIonLabel>
+        <IonSkeletonText animated />
+      </StyledIonLabel>
+    </StyledIonItem>
+  );
+};
+
+const StyledIonSkeletonText = styled(IonSkeletonText)`
+  line-height: inherit;
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+`;
+
+const IconContainer = styled.div`
+  position: relative;
+  display: inline-block;
+`;
+
+export default SkeletonLink;

--- a/app/src/components/menu/components/StyledIonItem.ts
+++ b/app/src/components/menu/components/StyledIonItem.ts
@@ -8,17 +8,10 @@ const StyledIonItem = styled(IonItem)`
     border-radius: 4px;
   }
 
-  ion-menu.md &.selected {
-    --background: rgba(var(--ion-color-primary-rgb), 0.14);
-  }
   ion-menu.ios & {
     --padding-start: 16px;
     --padding-end: 16px;
     --min-height: 50px;
-  }
-
-  &.selected {
-    --color: var(--ion-color-primary);
   }
 `;
 

--- a/app/src/contexts/Context.tsx
+++ b/app/src/contexts/Context.tsx
@@ -1,4 +1,5 @@
 import AssetTypeProvider from "./asset/AssetTypeContext";
+import CmsPageProvider from "./cms/CmsPageContext";
 import ProjectProvider from "./project/ProjectContext";
 import ProjectDataProvider from "./project/ProjectDataContext";
 
@@ -12,7 +13,9 @@ export default function Contexts(props: any) {
     <>
       <AssetTypeProvider>
         <ProjectProvider>
-          <ProjectDataProvider>{props.children}</ProjectDataProvider>
+          <ProjectDataProvider>
+            <CmsPageProvider>{props.children}</CmsPageProvider>
+          </ProjectDataProvider>
         </ProjectProvider>
       </AssetTypeProvider>
     </>

--- a/app/src/contexts/cms/CmsPageContext.tsx
+++ b/app/src/contexts/cms/CmsPageContext.tsx
@@ -1,0 +1,42 @@
+import { createContext, useState } from "react";
+import Api from "../../utilities/Api";
+
+// The actual context
+export const CmsPageContext = createContext<any>(null);
+
+//Create a provider wrapper to make the interaction with the context easier
+const CmsPageProvider: React.FC<React.ReactNode> = ({ children }) => {
+  //Create default state for the page list (used in menus etc)
+  const [CmsPages, setCmsPages] = useState<ICmsPageProvider>([]);
+
+  //Create default state for the page content (used when displaying a page)
+  const [CmsContent, setCmsContent] = useState<ICmsContentProvider>([]);
+
+  /**
+   * Refresh Context
+   * Replace pages in context
+   */
+  async function refreshPages() {
+    setCmsPages(await Api("cms/list.php"));
+  }
+
+  /**
+   * Get or refresh the content of a page
+   */
+  async function getPage(id: number) {
+    setCmsContent([
+      ...CmsContent.filter((page: CmsContent) => page.cmsPages_id != id),
+      await Api("cms/get.php", { p: id }, "POST"),
+    ]);
+  }
+
+  return (
+    <CmsPageContext.Provider
+      value={{ CmsPages, CmsContent, refreshPages, getPage }}
+    >
+      {children}
+    </CmsPageContext.Provider>
+  );
+};
+
+export default CmsPageProvider;

--- a/app/src/pages/assets/Asset.tsx
+++ b/app/src/pages/assets/Asset.tsx
@@ -9,8 +9,6 @@ import {
   IonItem,
   IonLabel,
   IonList,
-  IonRefresher,
-  IonRefresherContent,
   IonRow,
 } from "@ionic/react";
 import { useContext } from "react";
@@ -19,6 +17,7 @@ import { AssetTypeContext } from "../../contexts/asset/AssetTypeContext";
 import { s3url, fileExtensionToIcon, formatSize } from "../../utilities/Files";
 import Page from "../../components/Page";
 import { faBan, faFlag } from "@fortawesome/free-solid-svg-icons";
+import Refresher from "../../components/Refresher";
 
 /**
  * Asset Page
@@ -48,9 +47,7 @@ const Asset = () => {
     //return page layout
     return (
       <Page title={thisAsset.assets_tag_format}>
-        <IonRefresher slot="fixed" onIonRefresh={doRefresh}>
-          <IonRefresherContent />
-        </IonRefresher>
+        <Refresher onRefresh={doRefresh} />
 
         {/* Maintenance */}
         {thisAsset.flagsblocks.BLOCK.map((block: any) => {

--- a/app/src/pages/assets/AssetType.tsx
+++ b/app/src/pages/assets/AssetType.tsx
@@ -9,8 +9,6 @@ import {
   IonItem,
   IonLabel,
   IonList,
-  IonRefresher,
-  IonRefresherContent,
   IonRow,
   IonSlide,
   IonSlides,
@@ -22,6 +20,7 @@ import { fileExtensionToIcon, formatSize, s3url } from "../../utilities/Files";
 import { AssetTypeContext } from "../../contexts/asset/AssetTypeContext";
 import Page from "../../components/Page";
 import AssetItem from "../../components/assets/AssetItem";
+import Refresher from "../../components/Refresher";
 
 /**
  * Asset Type Page
@@ -99,9 +98,7 @@ const AssetType = () => {
     //return page layout
     return (
       <Page title={thisAssetType.assetTypes_name}>
-        <IonRefresher slot="fixed" onIonRefresh={doRefresh}>
-          <IonRefresherContent />
-        </IonRefresher>
+        <Refresher onRefresh={doRefresh} />
         {images}
         <IonCard>
           <IonCardContent>

--- a/app/src/pages/assets/AssetTypeList.tsx
+++ b/app/src/pages/assets/AssetTypeList.tsx
@@ -10,13 +10,12 @@ import {
   IonItem,
   IonLabel,
   IonList,
-  IonRefresher,
-  IonRefresherContent,
 } from "@ionic/react";
 import styled from "styled-components";
 import { useContext, useEffect } from "react";
 import { AssetTypeContext } from "../../contexts/asset/AssetTypeContext";
 import Page from "../../components/Page";
+import Refresher from "../../components/Refresher";
 
 /**
  * Asset Type List Page
@@ -46,9 +45,7 @@ const AssetTypeList = () => {
   if (AssetTypes) {
     return (
       <Page title="Asset List">
-        <IonRefresher slot="fixed" onIonRefresh={doRefresh}>
-          <IonRefresherContent />
-        </IonRefresher>
+        <Refresher onRefresh={doRefresh} />
         <IonCard>
           <IonList>
             {AssetTypes.assets.map((item: IAssetTypeData) => {
@@ -96,9 +93,7 @@ const AssetTypeList = () => {
     //If there is still no assets, it's probably a network issue
     return (
       <Page title="Asset List">
-        <IonRefresher slot="fixed" onIonRefresh={doRefresh}>
-          <IonRefresherContent />
-        </IonRefresher>
+        <Refresher onRefresh={doRefresh} />
         <IonCard>
           <IonCardTitle>No Assets found</IonCardTitle>
         </IonCard>

--- a/app/src/pages/cms/CmsPage.tsx
+++ b/app/src/pages/cms/CmsPage.tsx
@@ -1,0 +1,140 @@
+import { useParams } from "react-router";
+import { useContext, useEffect, useState } from "react";
+import { CmsPageContext } from "../../contexts/cms/CmsPageContext";
+import {
+  IonCard,
+  IonCardContent,
+  IonCardHeader,
+  IonCardTitle,
+  IonCol,
+  IonRow,
+} from "@ionic/react";
+import Page from "../../components/Page";
+import StyledIonSkeletonText from "../../components/StyledIonSkeletonText";
+import SkeletonCard from "../../components/SkeletonCard";
+import SummernoteContent from "../../components/SummernoteContent";
+import Refresher from "../../components/Refresher";
+
+/**
+ * Takes the output from the dropdown (bootstrap) colour menu in the dashboard and
+ * converts it to its Ionic equivalent.
+ * Set to undefined if no colour should be applied.
+ */
+const CARD_COLOR_MAP: CmsCardColorMapType = {
+  false: undefined, //No Colour
+  primary: "tertiary",
+  secondary: "light",
+  success: "success",
+  danger: "danger",
+  warning: "warning",
+  info: "secondary",
+  light: "light",
+  dark: "dark",
+};
+
+/**
+ * CMS Page
+ * Displays a single CMS Page
+ */
+const CmsPage = () => {
+  const { pageId } = useParams<{ pageId: string }>();
+  const { CmsContent, getPage } = useContext(CmsPageContext);
+  const [isLoading, setIsLoading] = useState(false);
+
+  /**
+   * Get the page data while setting the isLoading flag
+   * @param pageId the page id. Can be either a number or string as this is what the api accepts.
+   */
+  async function getPageData(pageId: number | string) {
+    setIsLoading(true);
+    await getPage(pageId);
+    setIsLoading(false);
+  }
+
+  /**
+   * Refresh the page
+   * @param event the refresh event
+   */
+  async function doRefresh(event: CustomEvent) {
+    await getPageData(pageId).then(() => {
+      event.detail.complete();
+    });
+  }
+
+  //Get data from API
+  useEffect(() => {
+    getPageData(pageId);
+  }, [pageId]);
+
+  //filter by requested asset type
+  const cmsPage = CmsContent.find(
+    (element: CmsContent) => element.cmsPages_id == parseInt(pageId),
+  );
+
+  // Setup variables for the content and title
+  let content = null;
+  let title;
+
+  // If there is data for the CMS page and there are cards on the page
+  if (
+    cmsPage &&
+    typeof cmsPage.DRAFTS.cmsPagesDrafts_dataARRAY.cards != "undefined"
+  ) {
+    title = cmsPage.cmsPages_name;
+    content = (
+      <IonRow>
+        {cmsPage.DRAFTS.cmsPagesDrafts_dataARRAY.cards.map(
+          (card: CmsContentCard, index: number) => (
+            <IonCol size={"12"} sizeLg={card.width} key={index}>
+              <IonCard color={card.color && CARD_COLOR_MAP[card.color]}>
+                <IonCardHeader>
+                  <IonCardTitle>{card.title}</IonCardTitle>
+                </IonCardHeader>
+                <IonCardContent>
+                  <SummernoteContent
+                    dangerouslySetInnerHTML={{
+                      __html: card.content.replace(/(\r\n|\n|\r)/gm, ""),
+                    }}
+                  />
+                </IonCardContent>
+              </IonCard>
+            </IonCol>
+          ),
+        )}
+      </IonRow>
+    );
+  }
+
+  // If the previous condition is not true (meaning we have not content to display),
+  // and we are not loading there must not be any content or the api call must have failed
+  else if (!isLoading) {
+    title = "Error";
+    content = (
+      <IonCard>
+        <IonCardHeader>
+          <IonCardTitle>There was an error!</IonCardTitle>
+        </IonCardHeader>
+        <IonCardContent>
+          We could not find any content for this page. This may mean there is no
+          content or that there is a network error. Please try again later
+        </IonCardContent>
+      </IonCard>
+    );
+  }
+
+  // If the previous two conditions are not true we must be loading from the api
+  else {
+    title = <StyledIonSkeletonText animated />;
+    content = <SkeletonCard />;
+  }
+
+  return (
+    <Page title={title}>
+      <Refresher onRefresh={doRefresh} />
+
+      {content}
+    </Page>
+  );
+};
+
+export default CmsPage;

--- a/app/src/pages/projects/Project.tsx
+++ b/app/src/pages/projects/Project.tsx
@@ -9,8 +9,6 @@ import {
   IonItem,
   IonLabel,
   IonList,
-  IonRefresher,
-  IonRefresherContent,
   IonRow,
   IonTitle,
   IonPopover,
@@ -22,6 +20,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { ProjectDataContext } from "../../contexts/project/ProjectDataContext";
 import Page from "../../components/Page";
 import { baseURL } from "../../utilities/Api";
+import Refresher from "../../components/Refresher";
 
 /**
  * Project Page
@@ -40,7 +39,7 @@ const Project = () => {
   //get individual project data
   useEffect(() => {
     refreshProjectData(parseInt(projectId));
-  }, []);
+  }, [projectId]);
 
   //Check project name
   let project_name = "AdamRMS Project";
@@ -50,9 +49,7 @@ const Project = () => {
 
   return (
     <Page title={project_name}>
-      <IonRefresher slot="fixed" onIonRefresh={doRefresh}>
-        <IonRefresherContent />
-      </IonRefresher>
+      <Refresher onRefresh={doRefresh} />
 
       {/* Project Data*/}
       <IonCard>

--- a/app/src/pages/projects/ProjectAssets.tsx
+++ b/app/src/pages/projects/ProjectAssets.tsx
@@ -10,8 +10,6 @@ import {
   IonItem,
   IonLabel,
   IonList,
-  IonRefresher,
-  IonRefresherContent,
   IonRow,
 } from "@ionic/react";
 import { useContext } from "react";
@@ -20,6 +18,7 @@ import AssetItem from "../../components/assets/AssetItem";
 import Page from "../../components/Page";
 import { ProjectDataContext } from "../../contexts/project/ProjectDataContext";
 import { MassFormatter, MoneyFormatter } from "../../utilities/Formatters";
+import Refresher from "../../components/Refresher";
 
 export interface IProjectAssets {
   assets: [IAssetTypeData];
@@ -164,9 +163,7 @@ const ProjectAssets = () => {
 
   return (
     <Page title="Project Assets">
-      <IonRefresher slot="fixed" onIonRefresh={doRefresh}>
-        <IonRefresherContent />
-      </IonRefresher>
+      <Refresher onRefresh={doRefresh} />
       {assets}
     </Page>
   );

--- a/app/src/pages/projects/ProjectList.tsx
+++ b/app/src/pages/projects/ProjectList.tsx
@@ -1,16 +1,9 @@
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  IonCard,
-  IonItem,
-  IonLabel,
-  IonList,
-  IonRefresher,
-  IonRefresherContent,
-  IonTitle,
-} from "@ionic/react";
+import { IonCard, IonItem, IonList, IonTitle } from "@ionic/react";
 import { useContext, useEffect } from "react";
 import { ProjectContext } from "../../contexts/project/ProjectContext";
 import Page from "../../components/Page";
+import NavList, { NavListItemType } from "../../components/NavList";
+import Refresher from "../../components/Refresher";
 
 /**
  * Project List Page
@@ -33,30 +26,19 @@ const ProjectList = () => {
   //generate project list if there are projects
   let projectList;
   if (projects) {
-    projectList = projects.map((item: IProject) => {
-      return (
-        <IonItem
-          key={item.projects_id}
-          routerLink={"/projects/" + item.projects_id}
-        >
-          <div slot="start">
-            {item.thisProjectManager && (
-              <FontAwesomeIcon icon="star" size="lg" />
-            )}
-            {!item.thisProjectManager && (
-              <FontAwesomeIcon icon={["far", "circle"]} size="lg" />
-            )}
-          </div>
-          <IonLabel>
-            <h2>{item.projects_name}</h2>
-            <p>{item.clients_name}</p>
-          </IonLabel>
-          <div slot="end">
-            <FontAwesomeIcon icon="arrow-right" />
-          </div>
-        </IonItem>
-      );
+    const listItems = projects.map((project: IProject): NavListItemType => {
+      return {
+        link: `/projects/${project.projects_id}/`,
+        icon: project.thisProjectManager ? "star" : ["far", "circle"],
+        content: (
+          <>
+            <h2>{project.projects_name}</h2>
+            <p>{project.clients_name}</p>
+          </>
+        ),
+      };
     });
+    projectList = <NavList items={listItems} />;
   } else {
     projectList = (
       <IonItem>
@@ -67,9 +49,7 @@ const ProjectList = () => {
 
   return (
     <Page title="Project List">
-      <IonRefresher slot="fixed" onIonRefresh={doRefresh}>
-        <IonRefresherContent />
-      </IonRefresher>
+      <Refresher onRefresh={doRefresh} />
       <IonCard>
         <IonList>{projectList}</IonList>
       </IonCard>

--- a/app/src/type.d.ts
+++ b/app/src/type.d.ts
@@ -103,3 +103,65 @@ interface IProjectData {
   assetsAssignmentsStatus: [...any];
   FINANCIALS: any;
 }
+
+/**
+ * CMS Page List
+ */
+interface CmsPageList {
+  cmsPages_fontAwesome: string | null;
+  cmsPages_name: string;
+  cmsPages_id: number;
+  SUBPAGES?: [...CmsPageList];
+}
+
+/**
+ * CMS Content
+ */
+interface CmsContent extends CmsPageList {
+  instances_id: number;
+  cmsPages_showNav: number;
+  cmsPages_showPublic: number;
+  cmsPages_showPublicNav: number;
+  cmsPages_visibleToGroups: number;
+  cmsPages_navOrder: number;
+  cmsPages_description: string;
+  cmsPages_archived: boolean;
+  cmsPages_deleted: boolean;
+  cmsPages_subOf: number | null;
+  cmsPages_added: Date;
+  DRAFTS: null | {
+    cmsPagesDrafts_id: number;
+    cmsPagesDrafts_data: string;
+    cmsPagesDrafts_revisionID: number;
+    cmsPagesDrafts_dataARRAY: Array<CmsContentCard>;
+  };
+  CONTENT: string;
+}
+
+/**
+ * The content of a Card on a CMS page
+ */
+interface CmsContentCard {
+  color: string;
+  content: string;
+  outline: string;
+  title: string;
+  width: string;
+}
+
+/**
+ * The Cms Card Color Map type defined in the CMS Page
+ */
+interface CmsCardColorMapType {
+  [index: string]: string | undefined;
+}
+
+/**
+ * The CMS Context Provider type
+ */
+type ICmsPageProvider = Array<CmsPageList>;
+
+/**
+ * The CMS Context Provider type
+ */
+type ICmsContentProvider = Array<CmsContent>;

--- a/app/src/utilities/Api.tsx
+++ b/app/src/utilities/Api.tsx
@@ -3,7 +3,7 @@ import axios, { Method as MethodType } from "axios";
 /* Where is the API hosted?
  * N.B This is a temporary variable to be replaced when auth is added to the app!
  */
-export const baseURL = "http://192.168.19.128/admin/";
+export const baseURL = "http://admin.test/";
 
 //TODO: @jbithell will come back and wrap this into a class, and probably remove axios
 

--- a/app/src/utilities/Api.tsx
+++ b/app/src/utilities/Api.tsx
@@ -3,7 +3,7 @@ import axios, { Method as MethodType } from "axios";
 /* Where is the API hosted?
  * N.B This is a temporary variable to be replaced when auth is added to the app!
  */
-export const baseURL = "http://admin.test/";
+export const baseURL = "http://192.168.19.128/admin/";
 
 //TODO: @jbithell will come back and wrap this into a class, and probably remove axios
 

--- a/app/src/utilities/GenerateIconFromString.ts
+++ b/app/src/utilities/GenerateIconFromString.ts
@@ -1,0 +1,19 @@
+import { IconLookup } from "@fortawesome/free-solid-svg-icons";
+import { IconProp } from "@fortawesome/fontawesome-svg-core";
+
+/**
+ * Takes a string (which is outputted from Font Awesome Icon Picker in the dash) and converts it for use in React.
+ *
+ * Usage:
+ * <FontAwesomeIcon icon={ GenerateIconFromString(iconString) } />
+ *
+ * @param iconString The string to convert
+ */
+function GenerateIconFromString(iconString: string): IconProp {
+  const splitIcon = iconString.split(" ");
+  const iconPrefix = splitIcon[0];
+  const iconName = splitIcon[1].split(/-(.+)/)[1];
+  return { prefix: iconPrefix, iconName: iconName } as IconLookup;
+}
+
+export default GenerateIconFromString;

--- a/app/src/utilities/Route.tsx
+++ b/app/src/utilities/Route.tsx
@@ -7,6 +7,8 @@ import AssetTypeList from "../pages/assets/AssetTypeList";
 import Project from "../pages/projects/Project";
 import ProjectAssets from "../pages/projects/ProjectAssets";
 import ProjectList from "../pages/projects/ProjectList";
+import CmsPageList from "../pages/cms/CmsPageList";
+import CmsPage from "../pages/cms/CmsPage";
 
 /**
  * Add all routes to this component
@@ -23,11 +25,11 @@ export function Routes() {
       {/* Projects */}
       <Route path="/projects/" component={ProjectList} exact />
       <Route path="/projects/:projectId" component={Project} exact />
-      <Route
-        path="/projects/:projectId/assets"
-        component={ProjectAssets}
-        exact
-      />
+      <Route path="/projects/:projectId/assets" component={ProjectAssets} exact />
+
+      {/* CMS Pages */}
+      <Route path="/cms/" component={CmsPageList} exact />
+      <Route path="/cms/:pageId" component={CmsPage} exact />
     </>
   );
 }


### PR DESCRIPTION
By submitting a PR for this repository you accept the contributor license agreement. 

### Description

This PR has:

- Added CMS Page Viewing
- Added a NavList component to provide an easy to use navigation list in the future. Existing pages (such as ProjectList and CMS List) have been migrated to use this.
- Added a Refresher component to standardise the page refresh process. Any existing pages using IonRefresher and IonRefresherContent have been migrated to this new component.
- Added a Skeleton Card and Skeleton text component for use in the future (as well as CMS pages).
- A Summernote wrapper has been created to correctly style any summernote content in Ionic.

![3](https://user-images.githubusercontent.com/11817698/147855796-3bee8ed3-8286-495a-8c2e-69dde48be9de.png)
_Skeleton Texts are used for loading_
<br />
<br />
<br />


![1](https://user-images.githubusercontent.com/11817698/147855803-b9528fc2-875c-43e7-b67d-9e16f386dd14.png)
_See a list of all pages. **For ease of use on mobile I have chosen to only add top level pages to the side bar**._ 
<br />
<br />
<br />

![2](https://user-images.githubusercontent.com/11817698/147855839-8eafe0be-fc39-4dfd-b467-77a5a0f69387.png)
_Pages are displayed in native ionic using a written converter. Summernote converter has been written to ensure tables are styled and responsive and links are not odd colours._
<br />
<br />
<br />

![4](https://user-images.githubusercontent.com/11817698/147855878-0389af10-cf22-461b-b47b-f03bde5e13a0.png)
_Projects List page migrated to use the same components created in the above PR_
<br />
<br />
<br />




### References

> Include any links supporting this change such as a:
Closes #8 
Creates #16 

### Testing
This project does not use unit testing. If you really wanna test create pages on your dashboard and watch them magically appear in the app. 

- [x] This change adds test coverage for new/changed/fixed functionality
^^^ probably...


### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in the documentation repo
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `main`